### PR TITLE
Allows users to omit the last extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ For example, ``src/MyClass.js`` will be referred to as ``import MyClass from 'my
 However, in practice it is different from the real import path when you use because it is transpiled
 (for example, ``import MyClass from 'my-module/lib/MyClass.js'``).
 
+By default, esdoc will also include the file extension, e.g. ``.js``. With the ``extension`` option you are able to control
+whether the extension will be included (``true``, ``default``), or completely omitted (``false``).
+
 Therefore, convert the import path by using following setting.
 
 ```json
@@ -23,7 +26,8 @@ Therefore, convert the import path by using following setting.
       "option": {
         "replaces": [
           {"from": "^src/", "to": "lib/"}
-        ]
+        ],
+        "extension" : true|false
       }
     }
   ]
@@ -54,7 +58,8 @@ setup ``plugin`` property in ``esdoc.json``
       "option": {
         "replaces": [
           {"from": "^src/", "to": "lib"}
-        ]
+        ],
+        "extension" : true|false
       }
     }
   ]

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -12,6 +12,9 @@ export function onStart(ev) {
   for (let item of option.replaces) {
     item.from = new RegExp(item.from);
   }
+  if (typeof option.extension === 'undefined') {
+    option.extension = true;
+  }
 }
 
 /**
@@ -49,12 +52,15 @@ export function onHandleTag(ev) {
       importPath = importPath.replace(item.from, item.to);
     }
 
+    let actualImportPath = importPath
+    if (!option.extension) actualImportPath = actualImportPath.replace(/[.][^.]+$/, '');
+
     if (importPath === mainPath) {
       tag.importPath = packageName;
     } else if (packageName) {
-      tag.importPath = `${packageName}/${importPath}`;
+      tag.importPath = `${packageName}/${actualImportPath}`;
     } else {
-      tag.importPath = importPath;
+      tag.importPath = actualImportPath;
     }
   }
 }

--- a/test/fixture/esdoc.json
+++ b/test/fixture/esdoc.json
@@ -9,7 +9,8 @@
         "replaces": [
           {"from": "^src/", "to": "lib/"},
           {"from": "^lib/FooClass.js", "to": "lib/foo"}
-        ]
+        ],
+        "extension": false
       }
     }
   ]

--- a/test/src/ImportPathTest.js
+++ b/test/src/ImportPathTest.js
@@ -7,7 +7,7 @@ import assert from 'power-assert';
 describe('Import Path', ()=> {
   it('simply convert', ()=> {
     const html = fs.readFileSync('./test/fixture/esdoc/class/src/MyClass.js~MyClass.html').toString();
-    assert(html.includes('>esdoc-importpath-plugin/lib/MyClass.js<'));
+    assert(html.includes('>esdoc-importpath-plugin/lib/MyClass<'));
   });
 
   it('multiple convert', ()=>{


### PR DESCRIPTION
Does this suffice? Omitting only the last extension or would it be better to remove any extension at all, e.g. foo.babel.es will become foo instead of foo.babel?

Currently, this will remove only the last extension, e.g. foo.babel.es will become foo.babel instead of just foo.
