### PR TITLE
Update link to esdoc-importpath-plugin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This repository is deprecated.
 
-Please check https://github.com/esdoc/esdoc-optional-plugins/tree/master/esdoc-importpath-plugin
+Please check https://github.com/esdoc/esdoc-plugins/tree/master/esdoc-importpath-plugin
 
 <br/>
 <br/>


### PR DESCRIPTION
The current link - https://github.com/esdoc/esdoc-optional-plugins/tree/master/esdoc-importpath-plugin - results in a 404 Not Found. This commit updates the README to point to the proper esdoc-importpath-plugin URL - https://github.com/esdoc/esdoc-plugins/tree/master/esdoc-importpath-plugin.